### PR TITLE
Made land-replacement optional depending on whether LANDEDITION is defined.

### DIFF
--- a/DeckUtils.cpp
+++ b/DeckUtils.cpp
@@ -129,9 +129,11 @@ void DeckUtils::convert_deck(std::string name)
     std::stringstream ss;
     for (std::list<Card*>::iterator it = l.begin(); it != l.end(); ++it) {
         if ((*it)->GetName() == "Island" || (*it)->GetName() == "Plains" || (*it)->GetName() == "Swamp" ||
-            (*it)->GetName() == "Mountain" || (*it)->GetName() == "Forest")
-            deck.replaceCard(new Card((*it)->GetName(), LANDEDITION,mdb.getCardNumber((*it)->GetName(),LANDEDITION)));
-        else {
+            (*it)->GetName() == "Mountain" || (*it)->GetName() == "Forest") {
+            if (LANDEDITION) {
+            	deck.replaceCard(new Card((*it)->GetName(), LANDEDITION,mdb.getCardNumber((*it)->GetName(),LANDEDITION)));
+            }
+        } else {
             std::multimap<std::string,std::string> mmap = mdb.getExpansionNumber((*it)->GetName());
             std::string expansion,number;
             std::stringstream exps;

--- a/Defines.h
+++ b/Defines.h
@@ -1,7 +1,14 @@
 #define RELEASE
 #define CONVERT
 
+// Path to the images as used by the client
+#define PICTURE_DIRECTORY "/path/to/pictures"
+// Path to the database
+#define DATABASEDIRECTORY "/path/to/database"
+
+// If defined, the converter will automatically replace
+// all images of standard lands with those of the edition
+// specified here.
 #define LANDEDITION "UNH"
-#define PICTURE_DIRECTORY 
-#define DEBUGDECK 
-#define DATABASEDIRECTORY
+
+#define DEBUGDECK "debugdeck"

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+all:
+	g++  -c  "Card.cpp" -g -O0 -Wall -std=c++11  -o Card.cpp.o -I.
+	g++  -c  "DeckUtils.cpp" -g -O0 -Wall -std=c++11  -o DeckUtils.cpp.o -I.
+	g++  -c  "Deck.cpp" -g -O0 -Wall -std=c++11  -o Deck.cpp.o -I.
+	g++  -c  "Mdb.cpp" -g -O0 -Wall -std=c++11  -o Mdb.cpp.o -I.
+	g++  -c  "main.cpp" -g -O0 -Wall -std=c++11  -o main.cpp.o -I.
+	g++ -pthread -std=c++11 main.cpp.o Deck.cpp.o Card.cpp.o DeckUtils.cpp.o Mdb.cpp.o -lsqlite3 -ldl -o deck_convertor
+  
+clean:
+	rm *.o
+	rm deck_convertor


### PR DESCRIPTION
This way, if a user does not want to replace lands, she can simply remove the #define.